### PR TITLE
add ember-leaflet keyword

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,8 @@
   "version": "0.0.3",
   "description": "The default blueprint for ember-cli addons.",
   "keywords": [
-    "ember-addon"
+    "ember-addon",
+    "ember-leaflet"
   ],
   "license": "MIT",
   "author": "Dmitry (dio) Levashov",


### PR DESCRIPTION
New ember-leaflet website will auto fetch the addons using npm and the packages must have the ember-leaflet keyword.